### PR TITLE
Add support for redhat family sysv

### DIFF
--- a/files/circus.RedHat
+++ b/files/circus.RedHat
@@ -1,0 +1,82 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          circusd
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: circus master control daemon
+# Description:       This is a daemon that controls the circus minions
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+DESC="circus daemon"
+NAME=circusd
+DAEMON=/usr/bin/circusd
+PIDFILE="/var/run/$NAME.pid"
+LOCKFILE="/var/lock/subsys/$NAME"
+CONFIG=/etc/circus/circusd.ini
+DAEMON_ARGS="--daemon --pidfile $PIDFILE $CONFIG"
+
+# Read configuration variable file if it is present
+[ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+
+do_start() {
+    [ -x $DAEMON ] || exit 5
+    echo -n $"Starting $DESC $NAME: "
+    daemon $DAEMON "$DAEMON_ARGS"
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && touch $LOCKFILE
+    return $RETVAL
+}
+
+do_stop() {
+    echo -n $"Stopping $DESC $NAME: "
+    killproc $NAME
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f $LOCKFILE
+    return $RETVAL
+}
+
+do_restart() {
+    do_stop
+    do_start
+}
+
+rh_status() {
+    status $DAEMON
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        do_start
+    ;;
+    stop)
+        rh_status_q || exit 0
+        do_stop
+    ;;
+    restart|force-reload)
+        do_restart
+    ;;
+    status)
+        rh_status
+    ;;
+    #reload)
+        # not implemented
+        #;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|force-reload}"
+        exit 2
+        ;;
+esac
+
+exit 0

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -32,7 +32,10 @@ class circus::configure {
     'sysv': {
       $dest_path = '/etc/init.d/circus'
       $dest_mode = '0755'
-      $extension = 'init'
+      $extension = $::osfamily ? {
+        'RedHat' => $::osfamily,
+        default  => 'init'
+      }
     }
     'upstart': {
       $dest_path = '/etc/init/circus.conf'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,6 +18,7 @@ class circus::install {
       ensure  => 'link',
       target  => '/usr/local/bin/circusd',
       require => Package[$::circus::package_circus],
+      replace => false,
     }
   }
 

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -11,6 +11,8 @@ describe 'circus::configure' do
     "include circus" ]
   end
 
+  let (:facts) {{:osfamily => ''}}
+
   it 'creates the required directories' do
     should contain_file('/etc/circus').with({
       :ensure => 'directory',
@@ -34,7 +36,6 @@ describe 'circus::configure' do
     })
   end
 
-
   it 'ensures circusd.ini exists' do
     should contain_file('/etc/circus/circusd.ini').with({
       :ensure => 'file',
@@ -44,6 +45,19 @@ describe 'circus::configure' do
     })
   end
 
+  context 'on RedHat system' do
+    let (:facts) {{:osfamily => 'RedHat'}}
+    it 'installs the RedHat init script' do
+      should contain_file('/etc/init.d/circus').with({
+        :ensure => 'file',
+        :source => 'puppet:///modules/circus/circus.RedHat',
+        :owner  => '0',
+        :group  => '0',
+        :mode   => '0755',
+        :notify => 'Class[Circus::Services]'
+      })
+    end
+  end
 
   it 'installs the init script' do
     should contain_file('/etc/init.d/circus').with({


### PR DESCRIPTION
The current sysv init file does not work on RedHat family systems (tested on RHEL & CentOS). These systems will also by default install (through pip) /usr/bin/circusd which then gets overwritten by a soft link to /usr/local/bin/circusd.
This PR should solve the above two issues.
