### PR TITLE
Add "copytruncate" to logrotate.

### DIFF
--- a/files/circus.logrotate
+++ b/files/circus.logrotate
@@ -5,4 +5,5 @@
 	rotate 7
 	compress
 	notifempty
+  copytruncate
 }


### PR DESCRIPTION
This adds copytruncate to the logrotate config. This prevents circus
from logging to a deleted file.
